### PR TITLE
[feat] cache 학습테스트 & 1,2 단계 미션

### DIFF
--- a/study/build.gradle
+++ b/study/build.gradle
@@ -19,7 +19,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'ch.qos.logback:logback-classic:1.5.7'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.4.1'

--- a/study/build.gradle
+++ b/study/build.gradle
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.4.1'

--- a/study/src/main/java/cache/com/example/GreetingController.java
+++ b/study/src/main/java/cache/com/example/GreetingController.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 public class GreetingController {

--- a/study/src/main/java/cache/com/example/cachecontrol/CacheInterceptor.java
+++ b/study/src/main/java/cache/com/example/cachecontrol/CacheInterceptor.java
@@ -1,4 +1,4 @@
-package cache.com.example.interceptor;
+package cache.com.example.cachecontrol;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/study/src/main/java/cache/com/example/cachecontrol/CacheWebConfig.java
+++ b/study/src/main/java/cache/com/example/cachecontrol/CacheWebConfig.java
@@ -1,5 +1,6 @@
 package cache.com.example.cachecontrol;
 
+import cache.com.example.interceptor.CacheInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,7 +8,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CacheWebConfig implements WebMvcConfigurer {
 
+    private final CacheInterceptor cacheInterceptor;
+
+    public CacheWebConfig() {
+        this.cacheInterceptor = new CacheInterceptor();
+    }
+
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(cacheInterceptor);
     }
 }

--- a/study/src/main/java/cache/com/example/cachecontrol/CacheWebConfig.java
+++ b/study/src/main/java/cache/com/example/cachecontrol/CacheWebConfig.java
@@ -1,6 +1,5 @@
 package cache.com.example.cachecontrol;
 
-import cache.com.example.interceptor.CacheInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -16,6 +15,7 @@ public class CacheWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(cacheInterceptor);
+        registry.addInterceptor(cacheInterceptor)
+                .addPathPatterns("/");
     }
 }

--- a/study/src/main/java/cache/com/example/etag/EtagFilterConfiguration.java
+++ b/study/src/main/java/cache/com/example/etag/EtagFilterConfiguration.java
@@ -1,12 +1,18 @@
 package cache.com.example.etag;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 public class EtagFilterConfiguration {
 
-//    @Bean
-//    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-//        return null;
-//    }
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean
+                = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/etag", "/resource/**");
+        return filterRegistrationBean;
+    }
 }

--- a/study/src/main/java/cache/com/example/interceptor/CacheInterceptor.java
+++ b/study/src/main/java/cache/com/example/interceptor/CacheInterceptor.java
@@ -1,0 +1,15 @@
+package cache.com.example.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+public class CacheInterceptor implements HandlerInterceptor {
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        response.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache, private");
+    }
+}

--- a/study/src/main/java/cache/com/example/version/CacheBustingWebConfig.java
+++ b/study/src/main/java/cache/com/example/version/CacheBustingWebConfig.java
@@ -2,8 +2,11 @@ package cache.com.example.version;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.Duration;
 
 @Configuration
 public class CacheBustingWebConfig implements WebMvcConfigurer {
@@ -20,6 +23,8 @@ public class CacheBustingWebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.addResourceHandler(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**")
-                .addResourceLocations("classpath:/static/");
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic())
+                .setEtagGenerator((resource) -> version.getVersion());
     }
 }

--- a/study/src/main/java/cache/com/example/version/ResourceVersion.java
+++ b/study/src/main/java/cache/com/example/version/ResourceVersion.java
@@ -2,7 +2,7 @@ package cache.com.example.version;
 
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 

--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -6,4 +6,5 @@ server:
     accept-count: 1
     max-connections: 1
     threads:
+      min-spare: 2
       max: 2

--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -8,3 +8,7 @@ server:
     threads:
       min-spare: 2
       max: 2
+  compression:
+    enabled: true
+    mime-types: text/html,text/plain,text/css,application/javascript,application/json
+    min-response-size: 100

--- a/tomcat/src/main/java/com/techcourse/controller/Controller.java
+++ b/tomcat/src/main/java/com/techcourse/controller/Controller.java
@@ -1,0 +1,12 @@
+package com.techcourse.controller;
+
+
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.response.HttpResponse;
+
+import java.io.IOException;
+
+public interface Controller {
+
+    HttpResponse execute(HttpRequest httpRequest) throws IOException;
+}

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -1,0 +1,61 @@
+package com.techcourse.controller;
+
+import com.techcourse.db.InMemoryUserRepository;
+import com.techcourse.model.User;
+import org.apache.catalina.Cookie;
+import org.apache.catalina.request.HttpMethod;
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.response.HttpResponse;
+import org.apache.catalina.session.Session;
+import org.apache.catalina.session.SessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class LoginController implements Controller {
+
+    private static final Logger log = LoggerFactory.getLogger(LoginController.class);
+
+    private final SessionManager sessionManager = SessionManager.getInstance();
+
+    @Override
+    public HttpResponse execute(HttpRequest httpRequest) {
+        HttpMethod httpMethod = httpRequest.getHttpMethod();
+        if (httpMethod == HttpMethod.GET) {
+            return getLoginPage(httpRequest);
+        }
+        if (httpMethod == HttpMethod.POST) {
+            return login(httpRequest);
+        }
+        return new HttpResponse(401);
+    }
+
+    private HttpResponse login(HttpRequest httpRequest) {
+        Map<String, String> params = httpRequest.getBody();
+        Optional<User> optionalUser = InMemoryUserRepository.findByAccount(params.get("account"));
+        if (optionalUser.isEmpty()) {
+            return new HttpResponse(302, "/401.html");
+        }
+        User user = optionalUser.get();
+        if (user.checkPassword(params.get("password"))) {
+            Session session = new Session();
+            session.setAttribute("user", user);
+            sessionManager.add(session);
+            log.info("{}", user);
+            Cookie cookie = new Cookie(Map.of("JSESSIONID", session.getId()));
+            return new HttpResponse(302, "/index.html", cookie);
+        }
+        return new HttpResponse(302, "/401.html");
+    }
+
+    public HttpResponse getLoginPage(HttpRequest httpRequest) {
+        String sessionId = httpRequest.getSessionId();
+        Session session = sessionManager.findSession(sessionId);
+        if (session.isPresent() && session.getAttribute("user") != null) {
+            return new HttpResponse(302, "/index.html");
+        }
+        return new HttpResponse(200, httpRequest.getUrl());
+    }
+}

--- a/tomcat/src/main/java/com/techcourse/controller/RegisterController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/RegisterController.java
@@ -1,0 +1,28 @@
+package com.techcourse.controller;
+
+import com.techcourse.db.InMemoryUserRepository;
+import com.techcourse.model.User;
+import org.apache.catalina.request.HttpMethod;
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.response.HttpResponse;
+
+import java.util.Map;
+
+public class RegisterController implements Controller {
+
+    @Override
+    public HttpResponse execute(HttpRequest httpRequest) {
+        if (httpRequest.getHttpMethod() == HttpMethod.GET) {
+            return new HttpResponse(200, httpRequest.getUrl());
+        }
+        if (httpRequest.getHttpMethod() == HttpMethod.POST) {
+            Map<String, String> payload = httpRequest.getBody();
+            User user = new User(payload.get("account"), payload.get("password"), payload.get("email"));
+            InMemoryUserRepository.save(user);
+
+            return new HttpResponse(302, "/index.html");
+        }
+
+        return new HttpResponse(400);
+    }
+}

--- a/tomcat/src/main/java/com/techcourse/controller/StaticResourceController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/StaticResourceController.java
@@ -1,0 +1,12 @@
+package com.techcourse.controller;
+
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.response.HttpResponse;
+
+public class StaticResourceController implements Controller {
+
+    @Override
+    public HttpResponse execute(HttpRequest httpRequest) {
+        return new HttpResponse(200, httpRequest.getUrl());
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/Cookie.java
+++ b/tomcat/src/main/java/org/apache/catalina/Cookie.java
@@ -1,0 +1,33 @@
+package org.apache.catalina;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Cookie {
+    private static final String COOKIE_DELIMITER = "&";
+    private static final String SPLIT_DELIMITER = "=";
+
+    private final Map<String, String> values;
+
+    public Cookie(Map<String, String> values) {
+        this.values = values;
+    }
+
+    public static Cookie parse(String cookie) {
+        if (cookie == null) {
+            return new Cookie(Map.of());
+        }
+
+        Map<String, String> values = new HashMap<>();
+        String[] splits = cookie.split(COOKIE_DELIMITER);
+        for (String split : splits) {
+            String[] keyValue = split.split(SPLIT_DELIMITER);
+            values.put(keyValue[0], keyValue[1]);
+        }
+        return new Cookie(values);
+    }
+
+    public String getValue(String key) {
+        return values.getOrDefault(key, null);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/HandlerAdapter.java
+++ b/tomcat/src/main/java/org/apache/catalina/HandlerAdapter.java
@@ -1,0 +1,26 @@
+package org.apache.catalina;
+
+import com.techcourse.controller.Controller;
+import com.techcourse.controller.LoginController;
+import com.techcourse.controller.RegisterController;
+import com.techcourse.controller.StaticResourceController;
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.response.HttpResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class HandlerAdapter {
+
+    private final Map<String, Controller> handler = Map.of(
+            "/login", new LoginController(),
+            "/register", new RegisterController()
+    );
+
+    public HttpResponse handle(HttpRequest httpRequest) throws IOException {
+        String url = httpRequest.getUrl();
+        Controller controller = handler.getOrDefault(url, new StaticResourceController());
+
+        return controller.execute(httpRequest);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/ResourceResolver.java
+++ b/tomcat/src/main/java/org/apache/catalina/ResourceResolver.java
@@ -1,0 +1,34 @@
+package org.apache.catalina;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+public class ResourceResolver {
+
+    public String resolve(String path) {
+        if (path == null) {
+            return null;
+        }
+        int extension = path.lastIndexOf(".");
+        URL url = getClass().getClassLoader().getResource("static" + path);
+        if (extension == -1) {
+            url = getClass().getClassLoader().getResource("static" + path + ".html");
+        }
+        return readFile(url);
+    }
+
+    private String readFile(URL url) {
+        if (url == null) {
+            return "Hello world!";
+        }
+        File file = new File(url.getFile());
+        try {
+            byte[] bytes = Files.readAllBytes(file.toPath());
+            return new String(bytes);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/Header.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/Header.java
@@ -1,0 +1,25 @@
+package org.apache.catalina.request;
+
+import java.util.Arrays;
+
+public enum Header {
+    CONTENT_LENGTH("Content-Length"),
+    CONTENT_TYPE("Content-Type"),
+    COOKIE("Cookie"),
+    HOST("Host"),
+    OTHER("Other"),
+    ;
+
+    private final String value;
+
+    Header(String value) {
+        this.value = value;
+    }
+
+    public static Header of(String value) {
+        return Arrays.stream(values())
+                .filter(header -> header.value.equals(value))
+                .findFirst()
+                .orElse(OTHER);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/HttpMethod.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/HttpMethod.java
@@ -1,0 +1,17 @@
+package org.apache.catalina.request;
+
+public enum HttpMethod {
+    GET("GET"),
+    POST("POST"),
+    ;
+
+    private final String value;
+
+    HttpMethod(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/HttpRequest.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/HttpRequest.java
@@ -1,0 +1,36 @@
+package org.apache.catalina.request;
+
+import org.apache.catalina.Cookie;
+
+import java.util.Map;
+
+public class HttpRequest {
+
+    private final StartLine startLine;
+    private final RequestHeader requestHeader;
+    private final RequestBody requestBody;
+
+    public HttpRequest(StartLine startLine, RequestHeader requestHeader, RequestBody requestBody) {
+        this.startLine = startLine;
+        this.requestHeader = requestHeader;
+        this.requestBody = requestBody;
+    }
+
+    public HttpMethod getHttpMethod() {
+        return startLine.getHttpMethod();
+    }
+
+    public String getUrl() {
+        return startLine.getUrl();
+    }
+
+    public Map<String, String> getBody() {
+        return requestBody.getBody();
+    }
+
+    public String getSessionId() {
+        String cookie = requestHeader.getCookie();
+        Cookie cookies = Cookie.parse(cookie);
+        return cookies.getValue("JSESSIONID");
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/RequestBody.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/RequestBody.java
@@ -1,0 +1,36 @@
+package org.apache.catalina.request;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequestBody {
+
+    private static final String BODY_DELIMITER = "&";
+    public static final String SPLIT_DELIMITER = "=";
+
+    private final Map<String, String> body;
+
+    private RequestBody(Map<String, String> body) {
+        this.body = body;
+    }
+
+    public static RequestBody parse(String rawBody) {
+        Map<String, String> body = new HashMap<>();
+
+        String[] params = rawBody.split(BODY_DELIMITER);
+        for (String param : params) {
+            String[] keyValue = param.split(SPLIT_DELIMITER);
+            body.put(keyValue[0], keyValue[1]);
+        }
+
+        return new RequestBody(body);
+    }
+
+    public static RequestBody empty() {
+        return new RequestBody(Map.of());
+    }
+
+    public Map<String, String> getBody() {
+        return body;
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/RequestHeader.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/RequestHeader.java
@@ -1,0 +1,39 @@
+package org.apache.catalina.request;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RequestHeader {
+
+    private static final String HEADER_DELIMITER = ": ";
+
+    private final Map<Header, String> headers;
+
+    private RequestHeader(Map<Header, String> headers) {
+        this.headers = headers;
+    }
+
+    public static RequestHeader parse(List<String> rawHeaders) {
+        Map<Header, String> headers = new HashMap<>();
+        for (String rawHeader : rawHeaders) {
+            String[] keyValue = rawHeader.split(HEADER_DELIMITER);
+            headers.put(Header.of(keyValue[0]), keyValue[1]);
+        }
+
+        return new RequestHeader(headers);
+    }
+
+    public boolean notContainsContentLength() {
+        return !headers.containsKey(Header.CONTENT_LENGTH);
+    }
+
+    public int getContentLength() {
+        String contentLength = headers.get(Header.CONTENT_LENGTH);
+        return Integer.parseInt(contentLength);
+    }
+
+    public String getCookie() {
+        return headers.get(Header.COOKIE);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/request/StartLine.java
+++ b/tomcat/src/main/java/org/apache/catalina/request/StartLine.java
@@ -1,0 +1,27 @@
+package org.apache.catalina.request;
+
+public class StartLine {
+
+    public static final String START_LINE_DELIMITER = " ";
+
+    private final HttpMethod httpMethod;
+    private final String url;
+
+    private StartLine(HttpMethod httpMethod, String url) {
+        this.httpMethod = httpMethod;
+        this.url = url;
+    }
+
+    public static StartLine parse(String rawStartLine) {
+        String[] splits = rawStartLine.split(START_LINE_DELIMITER);
+        return new StartLine(HttpMethod.valueOf(splits[0]), splits[1]);
+    }
+
+    public HttpMethod getHttpMethod() {
+        return httpMethod;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/catalina/response/HttpResponse.java
@@ -1,0 +1,40 @@
+package org.apache.catalina.response;
+
+import org.apache.catalina.Cookie;
+
+public class HttpResponse {
+
+    private final int statusCode;
+    private final Cookie cookie;
+    private final String resource;
+
+    public HttpResponse(int statusCode) {
+        this.statusCode = statusCode;
+        this.resource = null;
+        this.cookie = null;
+    }
+
+    public HttpResponse(int statusCode, String resource) {
+        this.statusCode = statusCode;
+        this.resource = resource;
+        this.cookie = null;
+    }
+
+    public HttpResponse(int statusCode, String resource, Cookie cookie) {
+        this.statusCode = statusCode;
+        this.resource = resource;
+        this.cookie = cookie;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Cookie getCookie() {
+        return cookie;
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/response/ResponseParser.java
+++ b/tomcat/src/main/java/org/apache/catalina/response/ResponseParser.java
@@ -1,0 +1,42 @@
+package org.apache.catalina.response;
+
+import org.apache.catalina.Cookie;
+import org.apache.catalina.ResourceResolver;
+
+public class ResponseParser {
+
+    private final ResourceResolver resourceResolver;
+
+    public ResponseParser() {
+        this.resourceResolver = new ResourceResolver();
+    }
+
+    public String parse(HttpResponse response) {
+        String responseBody = resourceResolver.resolve(response.getResource());
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(String.format("HTTP/1.1 %d OK ", response.getStatusCode())).append("\r\n");
+
+        Cookie cookie = response.getCookie();
+        if (cookie != null) {
+            stringBuilder.append("Set-Cookie: JSESSIONID=" + cookie.getValue("JSESSIONID") + "\r\n");
+        }
+
+        if (response.getStatusCode() == 302) {
+            stringBuilder.append("Location: " + response.getResource() + "\r\n");
+        }
+
+        stringBuilder.append("Content-Length: " + responseBody.getBytes().length + " ").append("\r\n")
+                .append("Content-Type: " + getContentType(response.getResource())).append("\r\n")
+                .append("\r\n").append(responseBody);
+
+        return stringBuilder.toString();
+    }
+
+    private String getContentType(String contentType) {
+        if (contentType.endsWith(".css")) {
+            return "text/css ";
+        }
+        return "text/html;charset=utf-8 ";
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/session/Session.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/Session.java
@@ -1,0 +1,39 @@
+package org.apache.catalina.session;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class Session {
+
+    private final String id;
+    private final Map<String, Object> values = new HashMap<>();
+
+    public Session() {
+        this(UUID.randomUUID().toString());
+    }
+
+    public Session(final String id) {
+        this.id = id;
+    }
+
+    public static Session empty() {
+        return new Session(null);
+    }
+
+    public boolean isPresent() {
+        return id != null;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Object getAttribute(final String name) {
+        return values.getOrDefault(name, null);
+    }
+
+    public void setAttribute(final String name, final Object value) {
+        values.put(name, value);
+    }
+}

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -1,0 +1,28 @@
+package org.apache.catalina.session;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SessionManager {
+
+    private static final Map<String, Session> SESSIONS = new HashMap<>();
+    private static final SessionManager INSTANCE = new SessionManager();
+
+    private SessionManager() {
+    }
+
+    public static SessionManager getInstance() {
+        if (INSTANCE == null) {
+            return new SessionManager();
+        }
+        return INSTANCE;
+    }
+
+    public void add(Session session) {
+        SESSIONS.put(session.getId(), session);
+    }
+
+    public Session findSession(String id) {
+        return SESSIONS.getOrDefault(id, Session.empty());
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,21 +1,38 @@
 package org.apache.coyote.http11;
 
 import com.techcourse.exception.UncheckedServletException;
+import org.apache.catalina.HandlerAdapter;
+import org.apache.catalina.request.HttpRequest;
+import org.apache.catalina.request.RequestBody;
+import org.apache.catalina.request.RequestHeader;
+import org.apache.catalina.request.StartLine;
+import org.apache.catalina.response.HttpResponse;
+import org.apache.catalina.response.ResponseParser;
 import org.apache.coyote.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.Socket;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Http11Processor implements Runnable, Processor {
 
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
 
     private final Socket connection;
+    private final HandlerAdapter handlerAdapter;
+    private final ResponseParser responseParser;
 
     public Http11Processor(final Socket connection) {
         this.connection = connection;
+        this.handlerAdapter = new HandlerAdapter();
+        this.responseParser = new ResponseParser();
     }
 
     @Override
@@ -28,20 +45,47 @@ public class Http11Processor implements Runnable, Processor {
     public void process(final Socket connection) {
         try (final var inputStream = connection.getInputStream();
              final var outputStream = connection.getOutputStream()) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
 
-            final var responseBody = "Hello world!";
+            StartLine startLine = readStartLine(in);
+            RequestHeader requestHeader = readHeader(in);
+            RequestBody requestBody = readBody(in, requestHeader);
+            HttpRequest httpRequest = new HttpRequest(startLine, requestHeader, requestBody);
 
-            final var response = String.join("\r\n",
-                    "HTTP/1.1 200 OK ",
-                    "Content-Type: text/html;charset=utf-8 ",
-                    "Content-Length: " + responseBody.getBytes().length + " ",
-                    "",
-                    responseBody);
+            HttpResponse httpResponse = handlerAdapter.handle(httpRequest);
 
+            String response = responseParser.parse(httpResponse);
             outputStream.write(response.getBytes());
             outputStream.flush();
+
+            in.close();
         } catch (IOException | UncheckedServletException e) {
             log.error(e.getMessage(), e);
         }
+    }
+
+    private StartLine readStartLine(BufferedReader in) throws IOException {
+        return StartLine.parse(in.readLine());
+    }
+
+    private RequestHeader readHeader(BufferedReader in) throws IOException {
+        String line;
+        List<String> headers = new ArrayList<>();
+        while ((line = in.readLine()) != null && !line.isBlank()) {
+            headers.add(line);
+        }
+        return RequestHeader.parse(headers);
+    }
+
+    private RequestBody readBody(BufferedReader in, RequestHeader requestHeader) throws IOException {
+        if (requestHeader.notContainsContentLength()) {
+            return RequestBody.empty();
+        }
+        int contentLength = requestHeader.getContentLength();
+        char[] buffer = new char[contentLength];
+        in.read(buffer, 0, contentLength);
+        String body = URLDecoder.decode(new String(buffer), StandardCharsets.UTF_8);
+
+        return RequestBody.parse(body);
     }
 }

--- a/tomcat/src/main/resources/static/login.html
+++ b/tomcat/src/main/resources/static/login.html
@@ -1,66 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <title>로그인</title>
-        <link href="css/styles.css" rel="stylesheet" />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js" crossorigin="anonymous"></script>
-    </head>
-    <body class="bg-primary">
-        <div id="layoutAuthentication">
-            <div id="layoutAuthentication_content">
-                <main>
-                    <div class="container">
-                        <div class="row justify-content-center">
-                            <div class="col-lg-5">
-                                <div class="card shadow-lg border-0 rounded-lg mt-5">
-                                    <div class="card-header"><h3 class="text-center font-weight-light my-4">로그인</h3></div>
-                                    <div class="card-body">
-                                        <form method="get" action="login">
-                                            <div class="form-floating mb-3">
-                                                <input class="form-control" id="inputLoginId" name="account" type="Text" placeholder="아이디를 입력하세요" />
-                                                <label for="inputLoginId">아이디</label>
-                                            </div>
-                                            <div class="form-floating mb-3">
-                                                <input class="form-control" id="inputPassword" name="password" type="password" placeholder="Password" />
-                                                <label for="inputPassword">비밀번호</label>
-                                            </div>
-                                            <div class="d-flex align-items-center justify-content-between mt-4 mb-0">
-                                                <button class="btn btn-primary" type="submit">로그인</button>
-                                            </div>
-                                        </form>
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+    <meta name="description" content=""/>
+    <meta name="author" content=""/>
+    <title>로그인</title>
+    <link href="css/styles.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js"
+            crossorigin="anonymous"></script>
+</head>
+<body class="bg-primary">
+<div id="layoutAuthentication">
+    <div id="layoutAuthentication_content">
+        <main>
+            <div class="container">
+                <div class="row justify-content-center">
+                    <div class="col-lg-5">
+                        <div class="card shadow-lg border-0 rounded-lg mt-5">
+                            <div class="card-header"><h3 class="text-center font-weight-light my-4">로그인</h3></div>
+                            <div class="card-body">
+                                <form method="post" action="login">
+                                    <div class="form-floating mb-3">
+                                        <input class="form-control" id="inputLoginId" name="account" type="Text"
+                                               placeholder="아이디를 입력하세요"/>
+                                        <label for="inputLoginId">아이디</label>
                                     </div>
-                                    <div class="card-footer text-center py-3">
-                                        <div class="small"><a href="register">아이디가 없나요? 회원가입 하러가기</a></div>
+                                    <div class="form-floating mb-3">
+                                        <input class="form-control" id="inputPassword" name="password" type="password"
+                                               placeholder="Password"/>
+                                        <label for="inputPassword">비밀번호</label>
                                     </div>
-                                </div>
+                                    <div class="d-flex align-items-center justify-content-between mt-4 mb-0">
+                                        <button class="btn btn-primary" type="submit">로그인</button>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="card-footer text-center py-3">
+                                <div class="small"><a href="register">아이디가 없나요? 회원가입 하러가기</a></div>
                             </div>
                         </div>
                     </div>
-                </main>
+                </div>
             </div>
-            <div id="layoutAuthentication_footer">
-                <footer class="py-4 bg-light mt-auto">
-                    <div class="container-fluid px-4">
-                        <div class="d-flex align-items-center justify-content-between small">
-                            <div class="text-muted">Copyright &copy; Your Website 2021</div>
-                            <div>
-                                <a href="index.html">Home</a>
-                                &middot;
-                                <a href="#">Privacy Policy</a>
-                                &middot;
-                                <a href="#">Terms &amp; Conditions</a>
-                            </div>
-                        </div>
+        </main>
+    </div>
+    <div id="layoutAuthentication_footer">
+        <footer class="py-4 bg-light mt-auto">
+            <div class="container-fluid px-4">
+                <div class="d-flex align-items-center justify-content-between small">
+                    <div class="text-muted">Copyright &copy; Your Website 2021</div>
+                    <div>
+                        <a href="index.html">Home</a>
+                        &middot;
+                        <a href="#">Privacy Policy</a>
+                        &middot;
+                        <a href="#">Terms &amp; Conditions</a>
                     </div>
-                </footer>
+                </div>
             </div>
-        </div>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-        <script src="js/scripts.js"></script>
-    </body>
+        </footer>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        crossorigin="anonymous"></script>
+<script src="js/scripts.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## **Cache-Control**

- [Mozilla Cache-Control Docs](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Cache-Control)

### 문법

다중 디렉티브는 **쉼표**로 구분됩니다.

```
Cache-Control: no-cache, no-store, must-revalidate
```

### Java 캐시 디렉티브(지시문) 지정

1. 디렉티브 별 지정

```java
public class CacheInterceptor implements HandlerInterceptor {

    @Override
    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
        response.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
        response.addHeader(HttpHeaders.CACHE_CONTROL, "private");
    }
}
```
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c1cec94c-e166-476a-afb3-967c7c723118">

<br><br>

2. 디렉티브 한 번에 지정

```java
public class CacheInterceptor implements HandlerInterceptor {

    @Override
    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
        response.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache, private");
    }
}
```

<img width="300" alt="image" src="https://github.com/user-attachments/assets/20ab785c-e3cc-46ef-9a6e-fe15dcc1e1b2"> 

### 테스트

```java
@Test
void testNoCachePrivate() {
    final var response = webTestClient
            .get()
            .uri("/")
            .exchange()
            .expectStatus().isOk()
            **.expectHeader().cacheControl(CacheControl.noCache().cachePrivate())**
            .expectBody(String.class).returnResult();

    log.info("response body\n{}", response.getResponseBody());
}
```

두 가지 모두 테스트를 통과한다. 

### 결론

하지만 MDN 문서에 따라 디렉티브는 **쉼표**로 구분하니 2번 방법을 채택하겠다.

## Transfer-Encoding

- [Mozilla Transfer-Encoding Docs](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Transfer-Encoding)

### chunked

데이터가 일련의 청크 내에서 전송됩니다. `Content-Length` 헤더는 이 경우 생략되며, 각 청크의 앞부분에 현재 청크의 길이가 16진수 형태로 오고 그 뒤에는 `\r\n`이 오고 그 다음에 청크 자체가 오며, 그 뒤에는 다시 '\r\n'이 옵니다. 종료 청크는 그것의 길이가 0인 것을 제외하면 일반적인 청크와 다르지 않습니다. 그 다음에는 (비어있을수도 있는) 연속된 엔티티 헤더 필드로 구성된 트레일러가 옵니다.

## ETag
`ETag`는 **특정 버전의 리소스에 대한 식별자**입니다. 

특정 URL의 리소스가 변경되면 새로운 `ETag` 값을 생성해야 합니다. 이를 비교하면 리소스의 두 표현이 동일한지 여부를 확인할 수 있습니다.

```java
@Configuration
public class EtagFilterConfiguration {

    @Bean
    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean
                = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
        filterRegistrationBean.addUrlPatterns("/etag");
        return filterRegistrationBean;
    }
}
```

첫번째 요청 Response: `ETag`

<img width="300" alt="스크린샷 2024-09-12 오후 2 05 57" src="https://github.com/user-attachments/assets/bafed4f5-515a-4ea5-80c3-b8afa95d7786">

두번째 요청 Request: `If-None-Match`

<img width="1005" alt="스크린샷 2024-09-12 오후 2 07 50" src="https://github.com/user-attachments/assets/a26ca41c-e7c8-418d-b336-490f0dfdac19">